### PR TITLE
Fix windows shim code for xclbin parser and sync interface file

### DIFF
--- a/src/runtime_src/core/pcie/driver/windows/include/XoclUser_INTF.h
+++ b/src/runtime_src/core/pcie/driver/windows/include/XoclUser_INTF.h
@@ -1,7 +1,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 //
+//    (C) Copyright 2021 OSR Open Systems Resources, Inc.
 //    (C) Copyright 2019-2021 Xilinx, Inc.
-//    (C) Copyright 2019 OSR Open Systems Resources, Inc.
+//    (C) Copyright 2019-2021 OSR Open Systems Resources, Inc.
 //    All Rights Reserved
 //
 //    ABSTRACT:
@@ -24,9 +25,9 @@ DEFINE_GUID(GUID_DEVINTERFACE_XOCL_USER,
 
 #define FILE_DEVICE_XOCL_USER   ((ULONG)0x8879)   // "XO"
 
-// 
+//
 // Constant string for the symbolic link associated with the device
-// 
+//
 #define XOCL_USER_BASE_DEVICE_NAME               L"XOCL_USER-"
 
 //
@@ -35,13 +36,9 @@ DEFINE_GUID(GUID_DEVINTERFACE_XOCL_USER,
 #define XOCL_USER_DEVICE_BUFFER_OBJECT_NAMESPACE L"\\Buffer"
 #define XOCL_USER_DEVICE_DEVICE_NAMESPACE        L"\\Device"
 
-// Windows kernel return status values. The values is equal to definitions in <ntstatus.h>
-#define NTSTATUS_REVISION_MISMATCH   0xC0000059
-#define NTSTATUS_STATUS_SUCCESS      0x00000000
-
 //
 // IOCTL Codes and structures supported by XoclUser
-// 
+//
 
 typedef enum _XOCL_BUFFER_SYNC_DIRECTION {
 
@@ -56,81 +53,13 @@ typedef enum _XOCL_BUFFER_TYPE {
     XOCL_BUFFER_TYPE_NORMAL = 0x3323,
     XOCL_BUFFER_TYPE_USERPTR,
     XOCL_BUFFER_TYPE_IMPORT,
-    XOCL_BUFFER_TYPE_CMA,
+    XOCL_BUFFER_TYPE_CMA,   // NOT USED
     XOCL_BUFFER_TYPE_P2P,
-    XOCL_BUFFER_TYPE_EXECBUF
+    XOCL_BUFFER_TYPE_EXECBUF,
+    XOCL_BUFFER_TYPE_HOST_ONLY,
+    XOCL_BUFFER_TYPE_DEVICE_ONLY
 
 } XOCL_BUFFER_TYPE, *PXOCL_BUFFER_TYPE;
-
-/**
- * struct xocl_kds - KDS user configuration
- *
- * @slot_size:  CQ slot size
- * @ert:        enable embedded HW scheduler
- * @polling:    poll for command completion
- * @cu_dma:     enable CUDMA custom module for HW scheduler
- * @cu_isr:     enable CUISR custom module for HW scheduler
- * @cq_int:     enable interrupt from host to HW scheduler
- * @dataflow:   enable dataflow mode
- * @rw_shared:  allow xclRegWrite/xclRegRead access shared CU
- */
-struct xocl_kds {
-    uint32_t slot_size;
-    uint32_t ert:1;
-    uint32_t polling:1;
-    uint32_t cu_dma:1;
-    uint32_t cu_isr:1;
-    uint32_t cq_int:1;
-    uint32_t dataflow:1;
-    uint32_t rw_shared:1;
-    uint32_t unused:25;
-};
-
-
-/**
- * struct xocl_axlf - load xclbin (AXLF) device image used with
- * IOCTL_XOCL_READ_AXLF ioctl
- *
- * @xclbin:	Pointer to user's xclbin structure in memory
- * @ksize:	size of kernels in bytes
- * @kernels:	pointer of argument array
- */
-struct xocl_axlf {
-	struct axlf     *xclbin;
-	size_t          ksize;
-	char            *kernels;
-	struct xocl_kds kds_cfg;
-};
-
-/**
- * struct argument_info - Kernel argument information
- *
- * @name:	argument name
- * @offset:	argument offset in CU
- * @size:	argument size in bytes
- * @dir:	input or output argument for a CU
- */
-struct argument_info {
-	char		name[64];
-	size_t  	offset;
-	size_t  	size;
-	uint32_t	dir;
-};
-
-/**
- * struct kernel_info - Kernel information
- *
- * @name:	kernel name
- * @range:	kernel register range
- * @anums:	number of argument
- * @args:	argument array
- */
-struct kernel_info {
-	char			 name[64];
-	size_t  		 range;
-	size_t			 anums;
-	struct argument_info	 args[1];
-};
 
 #define XOCL_MAX_DDR_BANKS    4
 
@@ -178,7 +107,7 @@ typedef struct _XOCL_CREATE_BO_ARGS {
 //
 // InBuffer  = XOCL_USERPTR_BO_ARGS
 // OutBuffer = (not used)
-// 
+//
 #define IOCTL_XOCL_USERPTR_BO       CTL_CODE(FILE_DEVICE_XOCL_USER, 2071, METHOD_BUFFERED, FILE_READ_DATA)
 //
 typedef struct _XOCL_USERPTR_BO_ARGS {
@@ -229,19 +158,70 @@ typedef struct _XOCL_INFO_BO_RESULT {
     XOCL_BUFFER_TYPE    BufferType;     // OUT: Buffer Type
 } XOCL_INFO_BO_RESULT, *PXOCL_INFO_BO_RESULT;
 
+
+#define	ICAP_XCLBIN_V2		"xclbin2"
+
+/**
+ * struct argument_info - Kernel argument information
+ *
+ * @name:	argument name
+ * @offset:	argument offset in CU
+ * @size:	argument size in bytes
+ * @dir:	input or output argument for a CU
+ */
+struct argument_info {
+    char        name[64];
+    size_t      offset;
+    size_t      size;
+    uint32_t    dir;
+};
+
+/**
+ * struct kernel_info - Kernel information
+ *
+ * @name:	kernel name
+ * @range:	kernel register range
+ * @anums:	number of argument
+ * @args:	argument array
+ */
+struct kernel_info {
+    char                    name[64];
+    size_t                  range;
+    size_t                  anums;
+    struct argument_info    *args;
+};
+
+struct xocl_kds{
+    uint32_t slot_size;
+    uint32_t ert : 1;
+    uint32_t polling : 1;
+    uint32_t cu_dma : 1;
+    uint32_t cu_isr : 1;
+    uint32_t cq_int : 1;
+    uint32_t dataflow : 1;
+    uint32_t rw_shared : 1;
+    uint32_t unused : 25;
+};
+
 //
 // IOCTL_XOCL_READ_AXLF
 //
 // InBuffer =  User data buffer pointer and size (containing AXLF File)
-// OutBuffer = (not used)
+// OutBuffer = XOCL_READ_AXLF_ARGS
 //
-#define IOCTL_XOCL_READ_AXLF        CTL_CODE(FILE_DEVICE_XOCL_USER, 2076, METHOD_BUFFERED, FILE_READ_DATA)
+typedef struct _XOCL_READ_AXLF_ARGS {
+    struct xocl_kds  kds_cfg; // IN: KDS user configuration
+    size_t           ksize;   // IN: size of kernels in bytes
+    CHAR*            kernels; // IN: pointer of kernel_info array
+} XOCL_READ_AXLF_ARGS, * PXOCL_READ_AXLF_ARGS;
+
+#define IOCTL_XOCL_READ_AXLF        CTL_CODE(FILE_DEVICE_XOCL_USER, 2076, METHOD_IN_DIRECT, FILE_READ_DATA)
 
 
 //
 // IOCTL_XOCL_MAP_BAR
 //
-// InBuffer =  (not used)
+// InBuffer =  XOCL_MAP_BAR_ARGS
 // OutBuffer = XOCL_MAP_BAR_RESULT
 //
 #define IOCTL_XOCL_MAP_BAR      CTL_CODE(FILE_DEVICE_XOCL_USER, 2077, METHOD_BUFFERED, FILE_READ_DATA)
@@ -256,7 +236,7 @@ typedef struct _XOCL_MAP_BAR_ARGS {
 } XOCL_MAP_BAR_ARGS, *PXOCL_MAP_BAR_ARGS;
 
 typedef struct _XOCL_MAP_BAR_RESULT {
-    PVOID       Bar;           // OUT: User VA of mapped buffer
+    PVOID           Bar;           // OUT: User VA of mapped buffer
     ULONGLONG       BarLength;     // OUT: Length of mapped buffer
 } XOCL_MAP_BAR_RESULT, *PXOCL_MAP_BAR_RESULT;
 
@@ -278,7 +258,6 @@ typedef enum _XOCL_STAT_CLASS {
     XoclStatKdsCU,
     XoclStatRomInfo,
     XoclStatDebugIpLayout
-
 } XOCL_STAT_CLASS, *PXOCL_STAT_CLASS;
 
 typedef struct _XOCL_STAT_CLASS_ARGS {
@@ -287,9 +266,9 @@ typedef struct _XOCL_STAT_CLASS_ARGS {
 
 } XOCL_STAT_CLASS_ARGS, *PXOCL_STAT_CLASS_ARGS;
 
-// 
+//
 // XoclStatDevice
-// 
+//
 typedef struct _XOCL_DEVICE_INFORMATION {
     ULONG  DeviceNumber;
     USHORT Vendor;
@@ -305,18 +284,10 @@ typedef struct _XOCL_DEVICE_INFORMATION {
     ULONG  LinkSpeed;
 
 } XOCL_DEVICE_INFORMATION, *PXOCL_DEVICE_INFORMATION;
-#if 0
-// 
-// XoclStatMemTopology
-// 
-typedef GUID xuid_t;
-#else
-typedef unsigned char xuid_t[16];
-#endif
 
-// 
+//
 // XoclStatMemRaw
-// 
+//
 typedef struct _XOCL_MEM_RAW {
     ULONGLONG               MemoryUsage;
     ULONGLONG               BOCount;
@@ -328,6 +299,7 @@ typedef struct _XOCL_MEM_RAW_INFORMATION {
     XOCL_MEM_RAW MemRaw[XOCL_MAX_DDR_BANKS];
 
 } XOCL_MEM_RAW_INFORMATION, *PXOCL_MEM_RAW_INFORMATION;
+
 #if 0
 //
 // XoclStatIpInfo
@@ -340,9 +312,9 @@ enum IP_TYPE {
 };
 #endif
 
-// 
+//
 // XoclStatKds
-// 
+//
 typedef struct _XOCL_KDS_INFORMATION {
     xuid_t    XclBinUuid;
     ULONG     OutstandingExecs;
@@ -352,9 +324,9 @@ typedef struct _XOCL_KDS_INFORMATION {
     ULONG     CuCount;
 } XOCL_KDS_INFORMATION, *PXOCL_KDS_INFORMATION;
 
-// 
+//
 // XoclStatKdsCU
-// 
+//
 typedef struct _XOCL_KDS_CU {
 
     ULONG BaseAddress;
@@ -373,10 +345,10 @@ typedef struct _XOCL_KDS_CU_INFORMATION {
 // XoclStatRomInfo
 //
 typedef struct _XOCL_ROM_INFORMATION {
-	UCHAR FPGAPartName[64];
-	UCHAR VBNVName[64];
-	uint8_t DDRChannelCount;
-	uint8_t DDRChannelSize;
+    UCHAR FPGAPartName[64];
+    UCHAR VBNVName[64];
+    uint8_t DDRChannelCount;
+    uint8_t DDRChannelSize;
 } XOCL_ROM_INFORMATION, *PXOCL_ROM_INFORMATION;
 
 //
@@ -389,7 +361,7 @@ typedef struct _XOCL_ROM_INFORMATION {
 #define IOCTL_XOCL_PREAD_BO         CTL_CODE(FILE_DEVICE_XOCL_USER, 2100, METHOD_OUT_DIRECT, FILE_READ_DATA)
 
 typedef struct _XOCL_PREAD_BO_ARGS {
-    ULONGLONG   Offset;     // IN: BO offset to read from 
+    ULONGLONG   Offset;     // IN: BO offset to read from
 } XOCL_PREAD_BO_ARGS, *PXOCL_PREAD_BO_ARGS;
 
 
@@ -403,7 +375,7 @@ typedef struct _XOCL_PREAD_BO_ARGS {
 #define IOCTL_XOCL_PWRITE_BO        CTL_CODE(FILE_DEVICE_XOCL_USER, 2101, METHOD_IN_DIRECT, FILE_READ_DATA)
 
 typedef struct _XOCL_PWRITE_BO_ARGS {
-    ULONGLONG   Offset;     // IN: BI offset to write to 
+    ULONGLONG   Offset;     // IN: BI offset to write to
 } XOCL_PWRITE_BO_ARGS, *PXOCL_PWRITE_BO_ARGS;
 
 
@@ -422,8 +394,20 @@ typedef enum _XOCL_CTX_OPERATION {
 
 }XOCL_CTX_OPERATION, *PXOCL_CTX_OPERATION;
 
-#define XOCL_CTX_FLAG_SHARED    0x0
-#define XOCL_CTX_FLAG_EXCLUSIVE 0x1
+/* Context properties */
+#define XOCL_CTX_PROP_MASK         0x0F
+#define XOCL_CTX_FLAG_SHARED       0x00
+#define XOCL_CTX_FLAG_EXCLUSIVE    0x01
+
+//
+// M2 NOTE
+// Is this used?
+//
+/* Virtual CU index
+ * This is useful when there is no need to open a context on hardware CU,
+ * but still need to lockdown the xclbin.
+ */
+#define	CU_CTX_VIRT_CU		0xffffffff
 
 typedef struct _XOCL_CTX_ARGS {
     XOCL_CTX_OPERATION Operation;   // IN: Alloc or free context
@@ -442,7 +426,6 @@ typedef struct _XOCL_CTX_ARGS {
 
 typedef struct _XOCL_EXECBUF_ARGS {
     HANDLE      ExecBO;
-    HANDLE      Deps[8];    // IN: Dependent Buffer Object handles
 } XOCL_EXECBUF_ARGS, *PXOCL_EXECBUF_ARGS;
 
 //
@@ -460,7 +443,7 @@ typedef struct _XOCL_EXECPOLL_ARGS {
 //
 // XOCL_PREAD_PWRITE_UNMGD_ARGS
 //Read IOCTL to unmanaged DDR memory
-// InputBuffer -  XOCL_PREAD_PWRITE_BO_UNMGD_ARGS  
+// InputBuffer -  XOCL_PREAD_PWRITE_BO_UNMGD_ARGS
 //OutputBuffer - (not used)
 
 #define IOCTL_XOCL_PREAD_UNMGD         CTL_CODE(FILE_DEVICE_XOCL_USER, 2105, METHOD_BUFFERED, FILE_READ_DATA)
@@ -476,7 +459,7 @@ typedef struct _XOCL_PREAD_PWRITE_UNMGD_ARGS {
 //
 // IOCTL_XOCL_PWRITE_UNMGD
 //Write IOCTL to unmanaged DDR memory
-// InputBuffer -  XOCL_PREAD_PWRITE_UNMGD_ARGS  
+// InputBuffer -  XOCL_PREAD_PWRITE_UNMGD_ARGS
 //OutputBuffer - (not used)
 
 #define IOCTL_XOCL_PWRITE_UNMGD        CTL_CODE(FILE_DEVICE_XOCL_USER, 2106, METHOD_BUFFERED, FILE_WRITE_DATA)
@@ -650,31 +633,62 @@ struct xcl_firewall {
 #define IOCTL_XOCL_MAILBOX_INFO          CTL_CODE(FILE_DEVICE_XOCL_USER, 2112, METHOD_BUFFERED, FILE_READ_DATA)
 
 enum mailbox_request {
-	MAILBOX_REQ_UNKNOWN = 0,
-	MAILBOX_REQ_TEST_READY = 1,
-	MAILBOX_REQ_TEST_READ = 2,
-	MAILBOX_REQ_LOCK_BITSTREAM = 3,
-	MAILBOX_REQ_UNLOCK_BITSTREAM = 4,
-	MAILBOX_REQ_HOT_RESET = 5,
-	MAILBOX_REQ_FIREWALL = 6,
-	MAILBOX_REQ_LOAD_XCLBIN_KADDR = 7,
-	MAILBOX_REQ_LOAD_XCLBIN = 8,
-	MAILBOX_REQ_RECLOCK = 9,
-	MAILBOX_REQ_PEER_DATA = 10,
-	MAILBOX_REQ_USER_PROBE = 11,
-	MAILBOX_REQ_MGMT_STATE = 12,
-	MAILBOX_REQ_CHG_SHELL = 13,
-	MAILBOX_REQ_PROGRAM_SHELL = 14,
-	MAILBOX_REQ_READ_P2P_BAR_ADDR = 15,
-	MAILBOX_REQ_MAX = 16,
-	/* Version 0 OP code ends */
+    MAILBOX_REQ_UNKNOWN = 0,
+    MAILBOX_REQ_TEST_READY = 1,
+    MAILBOX_REQ_TEST_READ = 2,
+    MAILBOX_REQ_LOCK_BITSTREAM = 3,
+    MAILBOX_REQ_UNLOCK_BITSTREAM = 4,
+    MAILBOX_REQ_HOT_RESET = 5,
+    MAILBOX_REQ_FIREWALL = 6,
+    MAILBOX_REQ_LOAD_XCLBIN_KADDR = 7,
+    MAILBOX_REQ_LOAD_XCLBIN = 8,
+    MAILBOX_REQ_RECLOCK = 9,
+    MAILBOX_REQ_PEER_DATA = 10,
+    MAILBOX_REQ_USER_PROBE = 11,
+    MAILBOX_REQ_MGMT_STATE = 12,
+    MAILBOX_REQ_CHG_SHELL = 13,
+    MAILBOX_REQ_PROGRAM_SHELL = 14,
+    MAILBOX_REQ_READ_P2P_BAR_ADDR = 15,
+    MAILBOX_REQ_MAX = 16,
+    /* Version 0 OP code ends */
 };
 
 /**
  * struct xcl_mailbox -  Data structure used to fetch mailbox group
  */
 struct xcl_mailbox {
-	/* recv metrics */
-	uint32_t          mbx_recv_raw_bytes;
-	uint32_t          mbx_recv_req[MAILBOX_REQ_MAX];
+    /* recv metrics */
+    uint32_t          mbx_recv_raw_bytes;
+    uint32_t          mbx_recv_req[MAILBOX_REQ_MAX];
 };
+
+//
+// IOCTL_XOCL_ALLOC_HOST_MEM
+//
+// InBuffer = XOCL_ALLOC_HOST_MEM_ARGS
+// OutBuffer = (not used)
+//
+//
+#define IOCTL_XOCL_ALLOC_HOST_MEM       CTL_CODE(FILE_DEVICE_XOCL_USER, 2201, METHOD_BUFFERED, FILE_READ_DATA)
+
+typedef struct _XOCL_ALLOC_HOST_MEM_ARGS {
+    ULONGLONG   SizeToAllocate;     // IN: Size, in bytes, to allocate
+} XOCL_ALLOC_HOST_MEM_ARGS, *PXOCL_ALLOC_HOST_MEM_ARGS;
+
+//
+// IOCTL_XOCL_FREE_HOST_MEM
+//
+// InBuffer = (not used)
+// OutBuffer = (not used)
+//
+//
+#define IOCTL_XOCL_FREE_HOST_MEM       CTL_CODE(FILE_DEVICE_XOCL_USER, 2202, METHOD_BUFFERED, FILE_READ_DATA)
+
+
+//
+// IOCTL_XOCL_GET_XCLBIN_SW_CHANNEL
+//
+// InBuffer = (not used)
+// OutBuffer = Message to be sent to Management (opaque to the caller)
+//
+#define IOCTL_XOCL_GET_XCLBIN_SW_CHANNEL       CTL_CODE(FILE_DEVICE_XOCL_USER, 2203, METHOD_OUT_DIRECT, FILE_READ_DATA)


### PR DESCRIPTION
updated shim code and updated interface file to latest from driver to make them synchronized. verified that shim code now works to program xclbins with xbutil